### PR TITLE
AL-6072 - fixed screenshot utils

### DIFF
--- a/src/utils/ScreenshotUtils.ts
+++ b/src/utils/ScreenshotUtils.ts
@@ -14,7 +14,7 @@ export abstract class ScreenshotUtils {
    */
   public static async screenshot(map: AlloyMap): Promise<Blob> {
     return new Promise<Blob>((resolve, reject) => {
-      map.olMap.once('rendercomplete', (event: RenderEvent) => {
+      map.olMap.once('postrender', (event: RenderEvent) => {
         try {
           // get the canvas
           const canvas: HTMLCanvasElement | null = map.olMap


### PR DESCRIPTION
Replaced `rendercomplete` with `postrender` event listener, checked in source code what happens when `map.renderSync()` is called and couldn't see it tirggering rendercomplete there (only on panning and zooming), but `postrender` is getting triggered at the end, and this seems to work.