### PR TITLE
AL-6340 - double halo fix

### DIFF
--- a/cypress/specs/all/features.ts
+++ b/cypress/specs/all/features.ts
@@ -41,7 +41,7 @@ export default function(mapData: MapData) {
           mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate()),
         );
         cy.wrap(featuresAtPixel).should('have.length', 1);
-        cy.wrap(featuresAtPixel![0]).should('equal', customFeature.olFeature);
+        cy.wrap(featuresAtPixel[0]).should('equal', customFeature.olFeature);
       });
     });
 
@@ -99,18 +99,19 @@ export default function(mapData: MapData) {
       );
 
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Click centre of the map
-        const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
-        return mapClick(pixel[0], pixel[1]);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        // Check that feature has been selected
-        cy.wrap(mapData.map.selectedFeatures.size).should('equal', 1);
-        cy.wrap(mapData.map.selectedFeatures.has(customFeature.id)).should('be.true');
-      });
+      cy.wait(100)
+        .then(() => {
+          // Click centre of the map
+          const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
+          return mapClick(pixel[0], pixel[1]);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          // Check that feature has been selected
+          cy.wrap(mapData.map.selectedFeatures.size).should('equal', 1);
+          cy.wrap(mapData.map.selectedFeatures.has(customFeature.id)).should('be.true');
+        });
     });
 
     it('should select multiple features on map on click with toggle mode', () => {
@@ -147,22 +148,25 @@ export default function(mapData: MapData) {
       );
 
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Click centre of the map
-        const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
-        mapClick(pixel[0], pixel[1]);
-        // Click second coordinate
-        const pixel2 = mapData.map.olMap.getPixelFromCoordinate(secondCoordinate.toMapCoordinate());
-        return mapClick(pixel2[0], pixel2[1]);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        // Check that both features has been selected
-        cy.wrap(mapData.map.selectedFeatures.size).should('equal', 2);
-        cy.wrap(mapData.map.selectedFeatures.has(customFeature.id)).should('be.true');
-        cy.wrap(mapData.map.selectedFeatures.has(customFeature2.id)).should('be.true');
-      });
+      cy.wait(100)
+        .then(() => {
+          // Click centre of the map
+          const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
+          mapClick(pixel[0], pixel[1]);
+          // Click second coordinate
+          const pixel2 = mapData.map.olMap.getPixelFromCoordinate(
+            secondCoordinate.toMapCoordinate(),
+          );
+          return mapClick(pixel2[0], pixel2[1]);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          // Check that both features has been selected
+          cy.wrap(mapData.map.selectedFeatures.size).should('equal', 2);
+          cy.wrap(mapData.map.selectedFeatures.has(customFeature.id)).should('be.true');
+          cy.wrap(mapData.map.selectedFeatures.has(customFeature2.id)).should('be.true');
+        });
     });
 
     it('should select feature on map programatically', () => {
@@ -219,14 +223,15 @@ export default function(mapData: MapData) {
       cy.wrap(mapData.map.selectedFeatures.has(customFeature.id)).should('be.true');
 
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Click somewhere else on the map to deselect it
-        const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
-        return mapClick(pixel[0] / 2, pixel[1] / 2);
-      })
-      .wait(100)
-      // Check that feature has been deselected
-      .then(() => cy.wrap(mapData.map.selectedFeatures).should('be.empty'));
+      cy.wait(100)
+        .then(() => {
+          // Click somewhere else on the map to deselect it
+          const pixel = mapData.map.olMap.getPixelFromCoordinate(mapCentre.toMapCoordinate());
+          return mapClick(pixel[0] / 2, pixel[1] / 2);
+        })
+        .wait(100)
+        // Check that feature has been deselected
+        .then(() => cy.wrap(mapData.map.selectedFeatures).should('be.empty'));
     });
 
     it('should remove selection from feature on map programatically', () => {
@@ -310,29 +315,30 @@ export default function(mapData: MapData) {
 
       let selectedFeatures: Map<string, AlloyFeature> | null = null;
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Add selection listener
-        mapData.map.addFeatureSelectionChangeListener((event) => {
-          selectedFeatures = event.features;
-        });
+      cy.wait(100)
+        .then(() => {
+          // Add selection listener
+          mapData.map.addFeatureSelectionChangeListener((event) => {
+            selectedFeatures = event.features;
+          });
 
-        // Click centre of the map to select feature
-        const pixel = mapData.map.olMap
-          .getPixelFromCoordinate(mapCentre.toMapCoordinate())
-          .map((p) => Math.round(p));
-        return mapClick(pixel[0], pixel[1]);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        if (!selectedFeatures) {
-          assert.fail('stack features are null');
-          return;
-        }
-        // Check that only one, top feature has been selected
-        cy.wrap(selectedFeatures.size).should('equal', 1);
-        cy.wrap(selectedFeatures.has(topFeature.id)).should('be.true');
-      });
+          // Click centre of the map to select feature
+          const pixel = mapData.map.olMap
+            .getPixelFromCoordinate(mapCentre.toMapCoordinate())
+            .map((p) => Math.round(p));
+          return mapClick(pixel[0], pixel[1]);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          if (!selectedFeatures) {
+            assert.fail('stack features are null');
+            return;
+          }
+          // Check that only one, top feature has been selected
+          cy.wrap(selectedFeatures.size).should('equal', 1);
+          cy.wrap(selectedFeatures.has(topFeature.id)).should('be.true');
+        });
     });
 
     it('should suggest features underneath stack of features on click', () => {
@@ -378,33 +384,34 @@ export default function(mapData: MapData) {
       let stack: Map<string, AlloyFeature> | null = null;
       let selectedFeature: AlloyFeature | null = null;
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Add under selection listener
-        mapData.map.addFeaturesUnderSelectionListener((event) => {
-          stack = event.stack;
-          selectedFeature = event.selectedFeature;
-        });
+      cy.wait(100)
+        .then(() => {
+          // Add under selection listener
+          mapData.map.addFeaturesUnderSelectionListener((event) => {
+            stack = event.stack;
+            selectedFeature = event.selectedFeature;
+          });
 
-        // Click centre of the map
-        const pixel = mapData.map.olMap
-          .getPixelFromCoordinate(mapCentre.toMapCoordinate())
-          .map((p) => Math.round(p));
-        return mapClick(pixel[0], pixel[1]);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        // Check that top feature has been selected
-        cy.wrap(selectedFeature).should('equal', topFeature);
-        if (!stack) {
-          assert.fail('stack features are null');
-          return;
-        }
-        // Check that other features at same coordinates have been returned in under selection
-        cy.wrap(stack.size).should('equal', 2);
-        cy.wrap(stack.has(feature1.id)).should('be.true');
-        cy.wrap(stack.has(feature2.id)).should('be.true');
-      });
+          // Click centre of the map
+          const pixel = mapData.map.olMap
+            .getPixelFromCoordinate(mapCentre.toMapCoordinate())
+            .map((p) => Math.round(p));
+          return mapClick(pixel[0], pixel[1]);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          // Check that top feature has been selected
+          cy.wrap(selectedFeature).should('equal', topFeature);
+          if (!stack) {
+            assert.fail('stack features are null');
+            return;
+          }
+          // Check that other features at same coordinates have been returned in under selection
+          cy.wrap(stack.size).should('equal', 2);
+          cy.wrap(stack.has(feature1.id)).should('be.true');
+          cy.wrap(stack.has(feature2.id)).should('be.true');
+        });
     });
 
     it('should multi select features on map on click', () => {
@@ -440,27 +447,28 @@ export default function(mapData: MapData) {
       );
 
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Click centre of the map
-        const pixel1 = mapData.map.olMap
-          .getPixelFromCoordinate(mapCentre.toMapCoordinate())
-          .map((p) => Math.round(p));
-        mapClick(pixel1[0], pixel1[1]);
+      cy.wait(100)
+        .then(() => {
+          // Click centre of the map
+          const pixel1 = mapData.map.olMap
+            .getPixelFromCoordinate(mapCentre.toMapCoordinate())
+            .map((p) => Math.round(p));
+          mapClick(pixel1[0], pixel1[1]);
 
-        // Shift+click map at the secondary coordinates
-        const pixel2 = mapData.map.olMap
-          .getPixelFromCoordinate(coordinate2.toMapCoordinate())
-          .map((p) => Math.round(p));
-        mapClick(pixel2[0], pixel2[1], true);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        // Check that both features have been selected
-        cy.wrap(mapData.map.selectedFeatures.size).should('equal', 2);
-        cy.wrap(mapData.map.selectedFeatures.has(feature1.id)).should('be.true');
-        cy.wrap(mapData.map.selectedFeatures.has(feature2.id)).should('be.true');
-      });
+          // Shift+click map at the secondary coordinates
+          const pixel2 = mapData.map.olMap
+            .getPixelFromCoordinate(coordinate2.toMapCoordinate())
+            .map((p) => Math.round(p));
+          mapClick(pixel2[0], pixel2[1], true);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          // Check that both features have been selected
+          cy.wrap(mapData.map.selectedFeatures.size).should('equal', 2);
+          cy.wrap(mapData.map.selectedFeatures.has(feature1.id)).should('be.true');
+          cy.wrap(mapData.map.selectedFeatures.has(feature2.id)).should('be.true');
+        });
     });
 
     it('should multi select features on map programatically', () => {
@@ -543,20 +551,21 @@ export default function(mapData: MapData) {
       mapData.map.selectFeatures([feature1, feature2]);
 
       // Wait for map to re-render
-      cy.wait(100).then(() => {
-        // Shift+click map at the secondary coordinates
-        const pixel = mapData.map.olMap
-          .getPixelFromCoordinate(coordinate2.toMapCoordinate())
-          .map((p) => Math.round(p));
-        return mapClick(pixel[0], pixel[1], true);
-      })
-      // Wait for map to re-render
-      .wait(100)
-      .then(() => {
-        // Check that second feature has been deselected
-        cy.wrap(mapData.map.selectedFeatures.size).should('equal', 1);
-        cy.wrap(mapData.map.selectedFeatures.has(feature1.id)).should('be.true');
-      });
+      cy.wait(100)
+        .then(() => {
+          // Shift+click map at the secondary coordinates
+          const pixel = mapData.map.olMap
+            .getPixelFromCoordinate(coordinate2.toMapCoordinate())
+            .map((p) => Math.round(p));
+          return mapClick(pixel[0], pixel[1], true);
+        })
+        // Wait for map to re-render
+        .wait(100)
+        .then(() => {
+          // Check that second feature has been deselected
+          cy.wrap(mapData.map.selectedFeatures.size).should('equal', 1);
+          cy.wrap(mapData.map.selectedFeatures.has(feature1.id)).should('be.true');
+        });
     });
 
     it('should not select non-selectable feature', () => {

--- a/src/map/core/AlloyMap.ts
+++ b/src/map/core/AlloyMap.ts
@@ -242,15 +242,15 @@ export class AlloyMap {
       ),
     );
 
-    // setup hover layer, interaction and add it to the map
-    this.hoverLayer = new AlloyHoverLayer({ map: this });
-    this.hoverInteraction = new AlloyHoverInteraction(this);
-    this.hoverLayer.olLayers.map((olLayer) => this.olMap.addLayer(olLayer));
-
     // setup selection layer, interaction and add it to the map
     this.selectionLayer = new AlloySelectionLayer({ map: this });
     this.selectionInteraction = new AlloySelectionInteraction(this);
     this.selectionLayer.olLayers.map((olLayer) => this.olMap.addLayer(olLayer));
+
+    // setup hover layer, interaction and add it to the map
+    this.hoverLayer = new AlloyHoverLayer({ map: this });
+    this.hoverInteraction = new AlloyHoverInteraction(this);
+    this.hoverLayer.olLayers.map((olLayer) => this.olMap.addLayer(olLayer));
 
     // setup ping interaction
     this.pingInteraction = new AlloyPingInteraction(this);

--- a/src/map/interactions/AlloyHoverInteraction.ts
+++ b/src/map/interactions/AlloyHoverInteraction.ts
@@ -160,7 +160,7 @@ export class AlloyHoverInteraction {
    * recalculates the payload of data used on pointer movement
    */
   private recalculatePointerMovePayload() {
-    const layers = Array.from(this.map.layers.values());
+    const layers = Array.from(this.map.layers.values()).concat(this.map.selectionLayer);
     const olLayers = _.flatten(layers.map((l) => l.olLayers));
 
     // TODO maybe work out the z-index?

--- a/src/map/interactions/AlloySelectionInteraction.ts
+++ b/src/map/interactions/AlloySelectionInteraction.ts
@@ -532,7 +532,7 @@ export class AlloySelectionInteraction {
    * @param pixel the pixel coordinate to find features under
    */
   private getFeaturesForPixel(pixel: number[]) {
-    const layers = Array.from(this.map.layers.values());
+    const layers = Array.from(this.map.layers.values()).concat(this.map.selectionLayer);
     // map the openlayers layers one to one with ours so indices are the same
     const olLayers = _.flatten(layers.map((l) => l.olLayers));
     // create a set for fast lookup

--- a/src/map/layers/selection/AlloySelectionLayer.ts
+++ b/src/map/layers/selection/AlloySelectionLayer.ts
@@ -53,6 +53,20 @@ export class AlloySelectionLayer extends AlloyLayerWithFeatures<AlloyFeature> {
   /**
    * @implements
    */
+  public removeFeature(feature: AlloyFeature): boolean {
+    if (feature.originatingLayerId) {
+      const layer = this.map.layers.get(feature.originatingLayerId);
+      if (layer instanceof AlloyLayerWithFeatures) {
+        layer.olSource.addFeature(feature.olFeature);
+      }
+    }
+
+    return super.removeFeature(feature);
+  }
+
+  /**
+   * @implements
+   */
   public clearFeatures(): boolean {
     Array.from(this.features.values()).forEach((feature) => {
       if (feature.originatingLayerId) {

--- a/src/map/layers/selection/AlloySelectionLayer.ts
+++ b/src/map/layers/selection/AlloySelectionLayer.ts
@@ -24,6 +24,51 @@ export class AlloySelectionLayer extends AlloyLayerWithFeatures<AlloyFeature> {
   /**
    * @implements
    */
+  public addFeature(feature: AlloyFeature): boolean {
+    if (feature.originatingLayerId) {
+      const layer = this.map.layers.get(feature.originatingLayerId);
+      if (layer instanceof AlloyLayerWithFeatures) {
+        layer.olSource.removeFeature(feature.olFeature);
+      }
+    }
+    return super.addFeature(feature);
+  }
+
+  /**
+   * @implements
+   */
+  public addFeatures(features: AlloyFeature[]): boolean {
+    features.forEach((feature) => {
+      if (feature.originatingLayerId) {
+        const layer = this.map.layers.get(feature.originatingLayerId);
+        if (layer instanceof AlloyLayerWithFeatures) {
+          layer.olSource.removeFeature(feature.olFeature);
+        }
+      }
+    });
+
+    return super.addFeatures(features);
+  }
+
+  /**
+   * @implements
+   */
+  public clearFeatures(): boolean {
+    Array.from(this.features.values()).forEach((feature) => {
+      if (feature.originatingLayerId) {
+        const layer = this.map.layers.get(feature.originatingLayerId);
+        if (layer instanceof AlloyLayerWithFeatures) {
+          layer.olSource.addFeature(feature.olFeature);
+        }
+      }
+    });
+
+    return super.clearFeatures();
+  }
+
+  /**
+   * @implements
+   */
   public dispose() {
     // nothing
   }


### PR DESCRIPTION
- Removing feature from the original layer when it gets selected.
- Adding feature back to the original layer when it gets deselected.

Since we have a custom selection interaction instead of default openlayers one, when features get selected they are added to a selection layer without being removed from/hidden in the original layer which was causing double halo rendering of the same feature.
This will also prevent issues if selected feature styles are different from default styles (i.e. selected point radius is smaller than default one).