### PR TITLE
AL-6475 - bump ECMAscript

### DIFF
--- a/src/map/features/AlloyAnimatedPathFeature.ts
+++ b/src/map/features/AlloyAnimatedPathFeature.ts
@@ -103,7 +103,7 @@ export abstract class AlloyAnimatedPathFeature implements AlloyFeature {
   public setGeometry(geometry: LineString | null) {
     this.animationManager.stopAnimation(this);
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));
       this.animationManager.startAnimation(this);

--- a/src/map/features/AlloyCustomFeatureBase.ts
+++ b/src/map/features/AlloyCustomFeatureBase.ts
@@ -109,7 +109,7 @@ export abstract class AlloyCustomFeatureBase implements AlloyFeature {
    */
   public setGeometry(geometry: Geometry | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       // allows any type
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));

--- a/src/map/features/AlloyDrawFeature.ts
+++ b/src/map/features/AlloyDrawFeature.ts
@@ -111,7 +111,7 @@ export class AlloyDrawFeature implements AlloyFeature {
    */
   public setGeometry(geometry: Geometry | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       const olGeometry = ProjectionUtils.GEOJSON.readGeometry(geometry);
       const geometryType = olGeometry.getType();

--- a/src/map/features/AlloyItemFeature.ts
+++ b/src/map/features/AlloyItemFeature.ts
@@ -114,7 +114,7 @@ export class AlloyItemFeature implements AlloyFeature, AlloyFeatureWithItemId {
    */
   public setGeometry(geometry: Geometry | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));
     }

--- a/src/map/features/AlloyPathNodeConnectorFeature.ts
+++ b/src/map/features/AlloyPathNodeConnectorFeature.ts
@@ -3,9 +3,9 @@ import OLFeature from 'ol/Feature';
 import OLLineString from 'ol/geom/LineString';
 import { FeatureUtils } from '../../utils/FeatureUtils';
 import { ProjectionUtils } from '../../utils/ProjectionUtils';
-import { AlloyPathNodeConnectorFeatureProperties } from './AlloyPathNodeConnectorFeatureProperties';
 import { AlloyFeature } from './AlloyFeature';
 import { AlloyFeatureType } from './AlloyFeatureType';
+import { AlloyPathNodeConnectorFeatureProperties } from './AlloyPathNodeConnectorFeatureProperties';
 
 /**
  * an alloy path node connector feature which represents a single line connector
@@ -92,7 +92,7 @@ export class AlloyPathNodeConnectorFeature implements AlloyFeature {
    */
   public setGeometry(geometry: LineString | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));
     }

--- a/src/map/features/AlloyPathNodeFeature.ts
+++ b/src/map/features/AlloyPathNodeFeature.ts
@@ -3,9 +3,9 @@ import OLFeature from 'ol/Feature';
 import OLPoint from 'ol/geom/Point';
 import { FeatureUtils } from '../../utils/FeatureUtils';
 import { ProjectionUtils } from '../../utils/ProjectionUtils';
-import { AlloyPathNodeFeatureProperties } from './AlloyPathNodeFeatureProperties';
 import { AlloyFeature } from './AlloyFeature';
 import { AlloyFeatureType } from './AlloyFeatureType';
+import { AlloyPathNodeFeatureProperties } from './AlloyPathNodeFeatureProperties';
 
 /**
  * an alloy path node feature which represents a connected unit with point geometry
@@ -93,7 +93,7 @@ export abstract class AlloyPathNodeFeature implements AlloyFeature {
    */
   public setGeometry(geometry: Point | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));
     }

--- a/src/map/features/AlloySimplifiedGeometryFeature.ts
+++ b/src/map/features/AlloySimplifiedGeometryFeature.ts
@@ -109,7 +109,7 @@ export class AlloySimplifiedGeometryFeature implements AlloyFeature {
    */
   public setGeometry(geometry: Geometry | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));
     }

--- a/src/map/features/AlloyWfsFeature.ts
+++ b/src/map/features/AlloyWfsFeature.ts
@@ -112,7 +112,7 @@ export class AlloyWfsFeature implements AlloyFeature {
    */
   public setGeometry(geometry: Geometry | null) {
     if (geometry === null) {
-      this.olFeature.setGeometry(undefined as any);
+      this.olFeature.setGeometry(undefined);
     } else {
       // allows any type
       this.olFeature.setGeometry(ProjectionUtils.GEOJSON.readGeometry(geometry));

--- a/src/map/styles/utils/AlloyLabelUtils.ts
+++ b/src/map/styles/utils/AlloyLabelUtils.ts
@@ -5,9 +5,9 @@ import OLRenderFeature from 'ol/render/Feature';
 import OLIcon from 'ol/style/Icon';
 import IconAnchorUnits from 'ol/style/IconAnchorUnits';
 import OLStyle from 'ol/style/Style';
+import { AlloyMapError } from '../../../error/AlloyMapError';
 import { ColourUtils } from '../../../utils/ColourUtils';
 import { AlloyLayerStyleScale } from '../AlloyLayerStyleScale';
-import { AlloyMapError } from '../../../error/AlloyMapError';
 
 /**
  * The size in pixels of the rendered label canvas
@@ -183,7 +183,7 @@ export abstract class AlloyLabelUtils {
     subtitle = subtitle ? AlloyLabelUtils.memoizedCleanText(subtitle) : null;
 
     // create a canvas to work on
-    const canvas = document.createElement('canvas') as HTMLCanvasElement;
+    const canvas = document.createElement('canvas');
     canvas.width = LABEL_CANVAS_HEIGHT;
     canvas.height = LABEL_CANVAS_HEIGHT;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2019",
     "module": "esnext",
     "declaration": true,
     "outDir": "./types",


### PR DESCRIPTION
The original jira was to bump it to es2020, but not all the browsers are up to scratch with that yet so we are going to es2019 instead. Which is still a significant jump.